### PR TITLE
Fix Logo Link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -207,7 +207,7 @@
                 <div class="mlg-navbar-container">
                     <span class="mlg-navbar-toggler-icon"></span>
                     <a href="https://mlg.eng.cam.ac.uk/" class="mlg-navbar-brand">
-                        <img src="https://mlg.eng.cam.ac.uk/preview/assets/logo/logo.png" alt="Cambridge Logo" class="mlg-navbar-logo">
+                        <img src="https://mlg.eng.cam.ac.uk/assets/logo/logo.png" alt="Cambridge Logo" class="mlg-navbar-logo">
                         <span class='mlg-title-hide-mobile mlg-navbar-title'>Machine Learning Group, Department of Engineering, Cambridge</span>
                         <span class='mlg-title-hide-desktop mlg-navbar-title'>MLG Cambridge</span>
                     </a>


### PR DESCRIPTION
Just noticed that, logo had link from a fork `preview` which is deleted now!